### PR TITLE
Data for connecting intervals

### DIFF
--- a/database.py
+++ b/database.py
@@ -617,6 +617,7 @@ class Database:
                 # Because intervals is a shelf, it needs a copy to know that something changed
                 intervals[intervalId] = intervalObj.copy()
                 count += 1
+                lastGuidIntervals[intervalObj['GUID']] = intervalId
             else:
                 lastGuidIntervals[intervalObj['GUID']] = intervalId
                 count += 1


### PR DESCRIPTION
***Note: this requires an updated dependency; make sure to run:***
```
source env/bin/activate
pip3 install -r requirements.txt --upgrade
```

Fixes #12 ... in theory, but we're not drawing the lines yet (so it could be wrong).

For now, this just stores an `intervalId` on every interval, as well as these three extra values for any interval that follows an upstream interval with the same GUID:

- `lastGuidIntervalId`
- `lastGuidLocation`
- `lastGuidEndTimestamp`

![image](https://user-images.githubusercontent.com/1215873/65185116-bceafe00-da1b-11e9-8bbe-7c1e0ef5d145.png)