### PR TITLE
Parent guids

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,12 @@ A simple example bundling the full phylanx output and an OTF2 trace:
   --label "2019-01-30 ALS Test Run"
 ```
 
-Bunding just an OTF2 trace, as well as a source code file (using OTF2 GUIDs to
-build the tree—note that, due to the combinatoric nature, this is slow!):
+Bunding just an OTF2 trace, as well as a source code file:
 ```bash
 ./bundle.py \
   --otf2 data/fibonacci-04Apr2018/OTF2_archive/APEX.otf2 \
   --python data/fibonacci-04Apr2018/fibonacci.py \
-  --label "2019-04-04 Fibonacci" \
-  --guids
+  --label "2019-04-04 Fibonacci"
 ```
 
 Loading many files at once (using a regular expression to match globbed paths):
@@ -70,8 +68,7 @@ Bringing it all together:
   --otf2 data/11July2019/factorial*/OTF2_archive/APEX.otf2 \
   --input data/11July2019/factorial*/output.txt \
   --physl data/factorial.physl \
-  --label "data\/(11July2019\/factorial[^/]*).*" \
-  --guids
+  --label "data\/(11July2019\/factorial[^/]*).*"
 ```
 
 ## Serving

--- a/bundle.py
+++ b/bundle.py
@@ -28,8 +28,6 @@ parser.add_argument('-c', '--cpp', dest='cpp', type=str, metavar='path', nargs='
                     help='Input C++ source code file')
 parser.add_argument('-s', '--debug', dest='debug', action='store_true',
                     help='Store additional information for debugging source files, etc.')
-parser.add_argument('-u', '--guids', dest='guids', action='store_true',
-                    help='Collect GUIDs')
 parser.add_argument('-e', '--events', dest='events', action='store_true',
                     help='Collect all events, not just intervals')
 
@@ -131,7 +129,7 @@ async def main():
 
             # Handle otf2
             if 'otf2' in paths:
-                await db.processOtf2(label, FakeFile(paths['otf2']), args['guids'], args['events'])
+                await db.processOtf2(label, FakeFile(paths['otf2']), args['events'])
 
             # Save all the data
             await db.save(label)

--- a/database.py
+++ b/database.py
@@ -361,7 +361,7 @@ class Database:
         await log('Finished parsing %s code' % codeType)
 
     def processEvent(self, label, event, eventId):
-        newR = seenR = newG = seenG = 0
+        newR = seenR = 0
 
         if 'Region' in event:
             # Identify the primitive (and add to its counter)
@@ -374,29 +374,6 @@ class Database:
                 if 'eventCount' not in primitive:
                     primitive['eventCount'] = 0
                 primitive['eventCount'] += 1
-
-            # Add to GUID / Parent GUID relationships
-            if self.datasets[label]['meta']['hasGuids'] and 'GUID' in event and 'Parent GUID' in event:
-                if 'guids' not in primitive:
-                    primitive['guids'] = [event['GUID']]
-                elif event['GUID'] not in primitive['guids']:
-                    # TODO: list lookups instead of set lookups aren't as optimal...
-                    # but storing sets may or may not be supported
-                    primitive['guids'].append(event['GUID'])
-                guid = self.datasets[label]['guids'].get(event['GUID'], None)
-                if guid is None:
-                    newG += 1
-                    guid = {
-                        'primitives': [primitiveName],
-                        'parent': event['Parent GUID']
-                    }
-                else:
-                    seenG += 1
-                    if primitiveName not in guid['primitives']:
-                        guid['primitives'].append(primitiveName)
-                    assert guid['parent'] == event['Parent GUID']
-                self.datasets[label]['guids'][event['GUID']] = guid
-
             self.datasets[label]['primitives'][primitiveName] = primitive
         # Add enter / leave events to per-location lists
         if event['Event'] == 'ENTER' or event['Event'] == 'LEAVE':
@@ -405,12 +382,12 @@ class Database:
                 # all this up in memory could be a problem...
                 self.sortedEventsByLocation[event['Location']] = sortedlist(key=lambda i: i[0])
             self.sortedEventsByLocation[event['Location']].add((event['Timestamp'], event))
-        # Add the event
-        if self.datasets[label]['meta']['hasEvents']:
+        # Store the event, if we're collecting them:
+        if self.datasets[label]['meta']['storedEvents']:
             self.datasets[label]['events'][eventId] = event
-        return (newR, seenR, newG, seenG)
+        return (newR, seenR)
 
-    async def processOtf2(self, label, file, parseGuids=False, storeEvents=False, log=logToConsole):
+    async def processOtf2(self, label, file, storeEvents=False, log=logToConsole):
         self.addSourceFile(label, file.name, 'otf2')
 
         # Set up database files
@@ -423,18 +400,16 @@ class Database:
             'both': {}
         }
         metricIndexes = self.datasets[label]['metricIndexes'] = {}
-        self.datasets[label]['meta']['hasGuids'] = parseGuids
-        if parseGuids:
-            guids = self.datasets[label]['guids'] = shelve.open(os.path.join(labelDir, 'guids.shelf'))
-        self.datasets[label]['meta']['hasEvents'] = storeEvents
+        guids = self.datasets[label]['guids'] = shelve.open(os.path.join(labelDir, 'guids.shelf'))
+        self.datasets[label]['meta']['storedEvents'] = storeEvents
         if storeEvents:
             self.datasets[label]['events'] = shelve.open(os.path.join(labelDir, 'events.shelf'))
 
         # Temporary counters / lists for sorting
         numEvents = 0
         self.sortedEventsByLocation = {}
-        await log('Parsing events (.=2500 events)')
-        newR = seenR = newG = seenG = 0
+        await log('Parsing OTF2 events (.=2500 events)')
+        newR = seenR = 0
         currentEvent = None
         for line in file:
             eventLineMatch = eventLineParser.match(line)
@@ -468,8 +443,6 @@ class Database:
                     # Add to primitive / guid counts
                     newR += counts[0]
                     seenR += counts[1]
-                    newG += counts[2]
-                    seenG += counts[3]
                 currentEvent = {}
                 currentEvent['Event'] = eventLineMatch.group(1)
                 currentEvent['Location'] = eventLineMatch.group(2)
@@ -490,21 +463,16 @@ class Database:
             counts = self.processEvent(label, currentEvent, str(numEvents))
             newR += counts[0]
             seenR += counts[1]
-            newG += counts[2]
-            seenG += counts[3]
         await log('')
         await log('Finished processing %i events' % numEvents)
         await log('New primitives: %d, References to existing primitives: %d' % (newR, seenR))
-        if parseGuids:
-            await log('New GUIDs: %d, Number of GUID references: %d' % (newG, seenG))
 
         # Now that we've seen all the locations, store that list in our metadata
         locationNames = self.datasets[label]['meta']['locationNames'] = sorted(self.sortedEventsByLocation.keys())
 
-        # Combine the sorted enter / leave events into intervals, and then index
-        # the intervals
+        # Combine the sorted enter / leave events into intervals
         await log('Combining enter / leave events into intervals (.=2500 intervals)')
-        numIntervals = 0
+        numIntervals = mismatchedIntervals = 0
         for location, eventList in self.sortedEventsByLocation.items():
             lastEvent = None
             for _, event in eventList:
@@ -522,13 +490,23 @@ class Database:
                         await log('WARNING: omitting LEAVE event without a prior ENTER event (%s)' % event['name'])
                         continue
                     intervalId = str(numIntervals)
-                    currentInterval = {'enter': {}, 'leave': {}, 'intervalId': intervalId }
-                    for attr, value in event.items():
-                        if attr != 'Timestamp' and value == lastEvent[attr]: #pylint: disable=unsubscriptable-object
-                            currentInterval[attr] = value
+                    currentInterval = {'enter': {}, 'leave': {}, 'intervalId': intervalId}
+                    # Copy all of the attributes from the OTF2 events into the interval object. If the values
+                    # differ (or it's the timestamp), put them in nested enter / leave objects. Otherwise, put
+                    # them directly in the interval object
+                    for attr in set(event.keys()).union(lastEvent.keys()):
+                        if attr not in event:
+                            currentInterval['enter'][attr] = lastEvent[attr]
+                        elif attr not in lastEvent:
+                            currentInterval['leave'][attr] = event[attr]
+                        elif attr != 'Timestamp' and event[attr] == lastEvent[attr]: #pylint: disable=unsubscriptable-object
+                            currentInterval[attr] = event[attr]
                         else:
                             currentInterval['enter'][attr] = lastEvent[attr] #pylint: disable=unsubscriptable-object
-                            currentInterval['leave'][attr] = value
+                            currentInterval['leave'][attr] = event[attr]
+                    # Count whether the primitive attribute differed between enter / leave
+                    if 'Primitive' not in currentInterval:
+                        mismatchedIntervals += 1
                     intervals[intervalId] = currentInterval
 
                     # Log that we've finished the finished interval
@@ -542,8 +520,9 @@ class Database:
             if lastEvent is not None:
                 # TODO: fibonacci data triggers this... why?
                 await log('WARNING: omitting trailing ENTER event (%s)' % lastEvent['Primitive'])
+        del self.sortedEventsByLocation
         await log('')
-        await log('Finished creating %i intervals' % numIntervals)
+        await log('Finished creating %i intervals; %i refer to mismatching primitives' % (numIntervals, mismatchedIntervals))
 
         # Now for indexing: we want per-location indexes, per-primitive indexes,
         # as well as both filters at the same time (we key by locations first)
@@ -599,49 +578,60 @@ class Database:
         await log('Finished indexing %i intervals' % count)
 
         await log('Connecting intervals with the same GUID (.=2500 intervals)')
-        guidCount = 0
-        count = 0
-        missingCount = 0
-        lastGuidIntervals = {}
+        intervalCount = missingCount = newLinks = seenLinks = 0
         for iv in intervalIndexes['main'].iterOverlap(endOrder=True):
             intervalId = iv.data
             intervalObj = intervals[intervalId]
-            if 'GUID' not in intervalObj:
-                missingCount += 1
-            elif intervalObj['GUID'] in lastGuidIntervals:
-                lastId = lastGuidIntervals[intervalObj['GUID']]
-                previousIv = intervals[lastId]
-                intervalObj['lastGuidIntervalId'] = lastId
-                intervalObj['lastGuidLocation'] = previousIv['Location']
-                intervalObj['lastGuidEndTimestamp'] = previousIv['leave']['Timestamp']
-                # Because intervals is a shelf, it needs a copy to know that something changed
-                intervals[intervalId] = intervalObj.copy()
-                count += 1
-                lastGuidIntervals[intervalObj['GUID']] = intervalId
-            else:
-                lastGuidIntervals[intervalObj['GUID']] = intervalId
-                count += 1
-                guidCount += 1
-        await log('Finished connecting %i intervals' % count)
-        await log('GUIDs used: %i, Intervals without GUIDs: %i' % (guidCount, missingCount))
 
-        # Create any missing parent-child primitive relationships based on the GUIDs we've collected
-        if parseGuids:
-            await log('Creating primitive links based on GUIDs (.=2500 GUIDs processed)')
-            newL = seenL = 0
-            for nGuid, guid in enumerate(guids.values()):
-                if guid['parent'] != '0':
-                    parentGuid = guids.get(guid['parent'], None)
-                    assert parentGuid is not None
-                    for parentPrimitive in parentGuid['primitives']:
-                        for childPrimitive in guid['primitives']:
-                            l = self.addPrimitiveChild(label, parentPrimitive, childPrimitive, 'otf2')[1]
-                            newL += l
-                            seenL += 1 if newL == 0 else 0
-                if nGuid > 0 and nGuid % 250 == 0:
-                    await log('.', end='')
-                if nGuid > 0 and nGuid % 10000 == 0:
-                    await log('scanned %i GUIDs' % nGuid)
-            await log('')
-            await log('Finished scanning %d GUIDs' % len(guids))
-            await log('New links: %d, Observed existing links: %d' % (newL, seenL))
+            # Parent GUIDs refer to the one in the enter event, not the leave event
+            guid = intervalObj.get('GUID', intervalObj['enter'].get('GUID', None))
+            if guid is None:
+                missingCount += 1
+                continue
+
+            # Connect to most recent interval with the parent GUID
+            parentGuid = intervalObj.get('Parent GUID', intervalObj['enter'].get('Parent GUID', None))
+            if parentGuid is not None and parentGuid in guids:
+                foundPrior = False
+                for parentIntervalId in reversed(guids[parentGuid]):
+                    parentInterval = intervals[parentIntervalId]
+                    if parentInterval['leave']['Timestamp'] <= intervalObj['enter']['Timestamp']:
+                        foundPrior = True
+                        intervalCount += 1
+                        # Store metadata about the most recent interval
+                        intervalObj['lastParentInterval'] = {
+                            'id': parentIntervalId,
+                            'location': parentInterval['Location'],
+                            'endTimestamp': parentInterval['leave']['Timestamp']
+                        }
+                        # Because intervals is a shelf, it needs a copy to know that something changed
+                        intervals[intervalId] = intervalObj.copy()
+
+                        # While we're here, note the parent-child link in the primitive graph
+                        # (for now, only assume links from the parent's leave interval to the
+                        # child's enter when primitive names are mismatched)
+                        child = intervalObj.get('Primitive', intervalObj['enter'].get('Primitive', None))
+                        parent = parentInterval.get('Primitive', intervalObj['leave'].get('Primitive', None))
+                        if child is not None and parent is not None:
+                            l = self.addPrimitiveChild(label, parent, child, 'otf2')[1]
+                            newLinks += l
+                            seenLinks += 1 if l == 0 else 0
+                        break
+                if not foundPrior:
+                    missingCount += 1
+            else:
+                missingCount += 1
+
+            # Store this interval by its leave GUID
+            if guid not in guids:
+                guids[guid] = []
+            guids[guid] = guids[guid] + [intervalId]
+
+            if (missingCount + intervalCount) % 2500 == 0:
+                await log('.', end='')
+            if (missingCount + intervalCount) % 100000 == 0:
+                await log('processed %i intervals' % (missingCount + intervalCount))
+
+        await log('Finished connecting intervals')
+        await log('Interval links created: %i, Intervals without prior parent GUIDs: %i' % (intervalCount, missingCount))
+        await log('New primitive links based on GUIDs: %d, Observed existing links: %d' % (newLinks, seenLinks))

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -324,8 +324,8 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       // Remove temporarily patched transformations
       this.content.select('.links').attr('transform', null);
     }
-    let link_data = data.filter(d => d.value.hasOwnProperty('lastGuidEndTimestamp'));
-    
+    let link_data = data.filter(d => d.value.hasOwnProperty('lastParentInterval'));
+
     let links = this.content.select('.links')
       .selectAll('.link').data(link_data, d => d.key);
     links.exit().remove();
@@ -339,9 +339,9 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     linksEnter.append('line')
       .classed('line', true);
     links.selectAll('line')
-      .attr('x1', d => this.xScale(d.value.lastGuidEndTimestamp))
+      .attr('x1', d => this.xScale(d.value.lastParentInterval.endTimestamp))
       .attr('x2', d => this.xScale(d.value.enter.Timestamp))
-      .attr('y1', d => this.yScale(d.value.lastGuidLocation) + halfwayOffset)
+      .attr('y1', d => this.yScale(d.value.lastParentInterval.location) + halfwayOffset)
       .attr('y2', d => this.yScale(d.value.Location) + halfwayOffset)
   }
   setupZoomAndPan () {

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -156,12 +156,11 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     // TODO: can probably do this immediately in a more light-weight way?
     this.linkedState.on('primitiveSelected', () => { this.render(); });
 
-
-     this.content.select('.background')
-        .on('click', () => {
-          this.linkedState.selectPrimitive(null);
-          this.render();
-        });
+    this.content.select('.background')
+      .on('click', () => {
+        this.linkedState.selectPrimitive(null);
+        this.render();
+      });
   }
   draw () {
     super.draw();
@@ -294,7 +293,7 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
         }
 
         this.render();
-      }).on('mouseenter',function(d) {
+      }).on('mouseenter', function (d) {
         if (!d.value.GUID) {
           console.warn(`No (consistent) GUID for interval: ${JSON.stringify(d.value, null, 2)}`);
           if (d.value.enter.GUID) {
@@ -305,13 +304,11 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
         }
         _self.render();
 
-
         window.controller.tooltip.show({
           content: `<pre>${JSON.stringify(d.value, null, 2)}</pre>`,
           targetBounds: this.getBoundingClientRect(),
           hideAfterMs: null
         });
-
       }).on('mouseleave', () => {
         window.controller.tooltip.hide();
         this.linkedState.selectGUID(null);
@@ -324,16 +321,16 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       // Remove temporarily patched transformations
       this.content.select('.links').attr('transform', null);
     }
-    let link_data = data.filter(d => d.value.hasOwnProperty('lastParentInterval'));
+    let linkData = data.filter(d => d.value.hasOwnProperty('lastParentInterval'));
 
     let links = this.content.select('.links')
-      .selectAll('.link').data(link_data, d => d.key);
+      .selectAll('.link').data(linkData, d => d.key);
     links.exit().remove();
     const linksEnter = links.enter().append('g')
       .classed('link', true);
     links = links.merge(linksEnter);
 
-    //links.attr('transform', d => `translate(${this.xScale(d.value.lastGuidEndTimestamp)},${this.yScale(d.value.lastGuidLocation)})`);
+    // links.attr('transform', d => `translate(${this.xScale(d.value.lastGuidEndTimestamp)},${this.yScale(d.value.lastGuidLocation)})`);
     let halfwayOffset = this.yScale.bandwidth() / 2;
 
     linksEnter.append('line')
@@ -342,7 +339,7 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       .attr('x1', d => this.xScale(d.value.lastParentInterval.endTimestamp))
       .attr('x2', d => this.xScale(d.value.enter.Timestamp))
       .attr('y1', d => this.yScale(d.value.lastParentInterval.location) + halfwayOffset)
-      .attr('y2', d => this.yScale(d.value.Location) + halfwayOffset)
+      .attr('y2', d => this.yScale(d.value.Location) + halfwayOffset);
   }
   setupZoomAndPan () {
     this.initialDragState = null;

--- a/static/views/GanttView/style.less
+++ b/static/views/GanttView/style.less
@@ -43,6 +43,7 @@
     .line {
       stroke-width: 1px;
       stroke: black; /* TODO: Unify me */
+      vector-effect: non-scaling-stroke;
     }
   }
 }


### PR DESCRIPTION
Links based on parent GUIDs should be working now:

![image](https://user-images.githubusercontent.com/1215873/66005535-a784c380-e460-11e9-9241-f58ba8184d96.png)

This also removes the `--guids` option that we weren't really using before, and links primitives based on `Parent GUID`s much more efficiently.