### PR TITLE
Fix the regex exponential handling for otf import

### DIFF
--- a/data_store/_otf2_functions.py
+++ b/data_store/_otf2_functions.py
@@ -104,8 +104,9 @@ async def processRawTrace(self, datasetId, file, log):
             metricType = metricLineMatch.group(3)
             # Usually group(4) is just a number, but sometimes we can get input
             # like "DOUBLE <2>; 1234.0000"... we want the last number
-            value = float(re.findall('[0-9.]+', metricLineMatch.group(4))[-1])
-
+            # convert string to numeric, make sure exponential numbers are handled
+            value = float(re.findall('[0-9.Ee+]+', metricLineMatch.group(4))[-1])
+            
             if metricType.startswith('PAPI'):
                 if currentEvent is None:
                     skippedMetricsForMissingPrior += 1


### PR DESCRIPTION
When large metrics  are written out by otf2-print they are in exponential format, this regex change fixes the import.