### PR TITLE
Fixes errors that hinder runtime

### DIFF
--- a/data_store/_otf2_functions.py
+++ b/data_store/_otf2_functions.py
@@ -260,6 +260,7 @@ async def combineIntervals(self, datasetId, log):
             # TODO: this seems to be triggered by recent distributed runs;
             # probably not a big deal as they're usually shudown_action events?
             await log('')
+            lastEvent = lastEventStack[-1]
             await log('\nWARNING: omitting trailing ENTER event (%s)' % lastEvent['Primitive'])
 
     # Clean up temporary lists

--- a/data_store/sparseUtilizationList.py
+++ b/data_store/sparseUtilizationList.py
@@ -12,6 +12,8 @@ class SparseUtilizationList():
         self.isUpdateCounter = isUpdate
 
     def getCLocation(self, loc):
+        if not loc in self.cLocationDict:
+            return []
         return self.cLocationDict[loc]
 
     def setCLocation(self, loc, val):
@@ -124,6 +126,8 @@ class SparseUtilizationList():
 
         # searches
         histogram = np.empty_like(criticalPts, dtype=object)
+        if not Location in self.locationDict:
+            return []
         location = self.locationDict[Location]
         length = len(location)
         histogram_length = len(histogram)


### PR DESCRIPTION
1. Gantt chart not rendering due to dict key error
2. `lastEvent` referenced before assignment

